### PR TITLE
Fixing lease owner check on start up

### DIFF
--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -66,7 +66,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
           take_or_renew_lease(s, state)
       end
 
-    if new_state.lease_owner == true do
+    if new_state.lease_holder do
       :ok = Pipeline.start(state.app_name, state.shard_id)
     end
 


### PR DESCRIPTION
Hey, I've been doing some debugging, not 100% this is correct, but from inspecting the data `lease_holder` is what you want to be checking as `lease_owner` is not a boolean.