### PR TITLE
Adding retries to get_records call

### DIFF
--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -66,7 +66,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
           take_or_renew_lease(s, state)
       end
 
-    if new_state.lease_holder == true do
+    if new_state.lease_holder do
       :ok = Pipeline.start(state.app_name, state.shard_id)
     end
 

--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -66,7 +66,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
           take_or_renew_lease(s, state)
       end
 
-    if new_state.lease_owner == true do
+    if new_state.lease_holder == true do
       :ok = Pipeline.start(state.app_name, state.shard_id)
     end
 

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -262,11 +262,9 @@ defmodule KinesisClient.Stream.Shard.Producer do
     {:noreply, messages, new_state}
   end
 
-  @retry with: exponential_backoff(500) |> expiry(10_000)
+  @retry with: constant_backoff(100) |> Stream.take(10)
   defp get_records_with_retry(state, kinesis_opts) do
-    result = {:ok, _} = Kinesis.get_records(state.shard_iterator, kinesis_opts)
-
-    result
+    Kinesis.get_records(state.shard_iterator, kinesis_opts)
   end
 
   defp get_shard_iterator(%{shard_iterator_type: :after_sequence_number} = state) do

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -262,7 +262,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
     {:noreply, messages, new_state}
   end
 
-  @retry with: exponential_backoff(500) |> Stream.take(4)
+  @retry with: exponential_backoff(500) |> Stream.take(5)
   defp get_records_with_retry(state, kinesis_opts) do
     Kinesis.get_records(state.shard_iterator, kinesis_opts)
   end

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -262,7 +262,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
     {:noreply, messages, new_state}
   end
 
-  @retry with: constant_backoff(100) |> Stream.take(10)
+  # @retry with: constant_backoff(100) |> Stream.take(10)
   defp get_records_with_retry(state, kinesis_opts) do
     Kinesis.get_records(state.shard_iterator, kinesis_opts)
   end

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -262,7 +262,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
     {:noreply, messages, new_state}
   end
 
-  # @retry with: constant_backoff(100) |> Stream.take(10)
+  @retry with: exponential_backoff(500) |> Stream.take(4)
   defp get_records_with_retry(state, kinesis_opts) do
     Kinesis.get_records(state.shard_iterator, kinesis_opts)
   end

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -3,6 +3,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
   Producer GenStage used in `KinesisClient.Stream.ShardConsumer` Broadway pipeline.
   """
   use GenStage
+  use Retry.Annotation
   require Logger
   alias KinesisClient.Kinesis
   alias KinesisClient.Stream.AppState
@@ -238,7 +239,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
        "NextShardIterator" => next_iterator,
        "MillisBehindLatest" => _millis_behind_latest,
        "Records" => records
-     }} = Kinesis.get_records(state.shard_iterator, Keyword.merge(kinesis_opts, limit: demand))
+     }} = get_records_with_retry(state.shard_iterator, Keyword.merge(kinesis_opts, limit: demand))
 
     new_demand = demand - length(records)
 
@@ -259,6 +260,13 @@ defmodule KinesisClient.Stream.Shard.Producer do
     }
 
     {:noreply, messages, new_state}
+  end
+
+  @retry with: exponential_backoff(500) |> expiry(10_000)
+  defp get_records_with_retry(state, kinesis_opts) do
+    result = {:ok, _} = Kinesis.get_records(state.shard_iterator, kinesis_opts)
+
+    result
   end
 
   defp get_shard_iterator(%{shard_iterator_type: :after_sequence_number} = state) do

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -239,7 +239,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
        "NextShardIterator" => next_iterator,
        "MillisBehindLatest" => _millis_behind_latest,
        "Records" => records
-     }} = get_records_with_retry(state.shard_iterator, Keyword.merge(kinesis_opts, limit: demand))
+     }} = get_records_with_retry(state, Keyword.merge(kinesis_opts, limit: demand))
 
     new_demand = demand - length(records)
 

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule KinesisClient.Mixfile do
       {:hackney, "~> 1.9"},
       {:jason, "~> 1.1"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
-      {:mox, "~> 0.5", only: :test}
+      {:mox, "~> 0.5", only: :test},
+      {:retry, "~> 0.14"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -25,6 +25,7 @@
   "mox": {:hex, :mox, "0.5.2", "55a0a5ba9ccc671518d068c8dddd20eeb436909ea79d1799e2209df7eaa98b6c", [:mix], [], "hexpm", "df4310628cd628ee181df93f50ddfd07be3e5ecc30232d3b6aadf30bdfe6092b"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
+  "retry": {:hex, :retry, "0.14.1", "722d1b0cf87096b71213f5801d99fface7ca76adc83fc9dbf3e1daee952aef10", [:mix], [], "hexpm", "b3a609f286f6fe4f6b2c15f32cd4a8a60427d78d05d7b68c2dd9110981111ae0"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.5.0", "8516502659002cec19e244ebd90d312183064be95025a319a6c7e89f4bccd65b", [:rebar3], [], "hexpm", "d48d002e15f5cc105a696cf2f1bbb3fc72b4b770a184d8420c8db20da2674b38"},


### PR DESCRIPTION
If the consumer needs to run on limited shards there is nothing stopping the `get_records` call from triggering the `ProvisionedThroughputExceededException`. Especially when the consumer needs to restart from the beginning of the stream. This PR introduces an exponential backoff to slow down the `get_records` calls.